### PR TITLE
Dashboard + Auth management UI; OpenAI OAuth callback runtime (180s auto-shutdown); OAuth state store; New Auth integration; Provider validation + UI fixes

### DIFF
--- a/lib/the_maestro/application.ex
+++ b/lib/the_maestro/application.ex
@@ -20,6 +20,9 @@ defmodule TheMaestro.Application do
       finch_child_spec(:openai_finch, finch_pools[:openai]),
       finch_child_spec(:gemini_finch, finch_pools[:gemini]),
       {Phoenix.PubSub, name: TheMaestro.PubSub},
+      # OAuth state store and runtime manager (server starts on-demand)
+      TheMaestro.OAuthState,
+      TheMaestro.OAuthCallbackRuntime,
       # Provider registry for automatic discovery and validation
       TheMaestro.ProviderRegistry,
       # Start to serve requests, typically the last entry

--- a/lib/the_maestro/oauth_callback_plug.ex
+++ b/lib/the_maestro/oauth_callback_plug.ex
@@ -1,0 +1,81 @@
+defmodule TheMaestro.OAuthCallbackPlug do
+  @moduledoc """
+  Minimal Plug to receive OAuth redirects on http://localhost:1455/auth/callback.
+
+  It reads `code` and `state`, looks up PKCE/session in `TheMaestro.OAuthState`,
+  completes the provider OAuth flow by calling `TheMaestro.Provider.create_session/3`,
+  and renders a simple HTML success or error page.
+  """
+
+  import Plug.Conn
+  alias TheMaestro.OAuthCallbackRuntime
+  alias TheMaestro.OAuthState
+  alias TheMaestro.Provider
+  require Logger
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{request_path: "/auth/callback"} = conn, _opts) do
+    params = fetch_query_params(conn).params
+    code = Map.get(params, "code")
+    state = Map.get(params, "state")
+
+    mapping = if is_binary(state), do: OAuthState.take(state), else: nil
+    case {code, state, mapping} do
+      {code, state, %{provider: provider, session_name: name, pkce_params: pkce}}
+      when is_binary(code) and is_binary(state) ->
+        result =
+          Provider.create_session(provider, :oauth,
+            name: name,
+            pkce_params: normalize_pkce(pkce),
+            auth_code: code
+          )
+
+        # Mapping already consumed via take/1; no further action
+        # Broadcast completion to UI and stop runtime server
+        case result do
+          {:ok, _} ->
+            TheMaestroWeb.Endpoint.broadcast("oauth:events", "completed", %{
+              provider: to_string(provider),
+              session_name: name
+            })
+            OAuthCallbackRuntime.notify_success()
+          _ -> :ok
+        end
+        respond(conn, result)
+
+      _ ->
+        respond(conn, {:error, :invalid_or_missing_state})
+    end
+  end
+
+  def call(conn, _opts) do
+    send_resp(conn, 404, "Not Found")
+  end
+
+  defp normalize_pkce(list) when is_list(list), do: Map.new(list)
+  defp normalize_pkce(%{code_verifier: _} = pkce), do: pkce
+  defp normalize_pkce(%TheMaestro.Auth.PKCEParams{} = pkce), do: Map.from_struct(pkce)
+  defp normalize_pkce(pkce) when is_map(pkce), do: pkce
+
+  defp respond(conn, {:ok, _session}) do
+    html = ~s(
+      <html><body style="font-family: system-ui;">
+        <h1>✅ OAuth Success</h1>
+        <p>You can return to the app. This window can be closed.</p>
+        <p><a href="/dashboard">Go to Dashboard</a></p>
+      </body></html>
+    )
+    send_resp(conn, 200, html)
+  end
+
+  defp respond(conn, {:error, reason}) do
+    html = ~s(
+      <html><body style="font-family: system-ui;color:#b91c1c;">
+        <h1>❌ OAuth Error</h1>
+        <p>#{Plug.HTML.html_escape(to_string(reason))}</p>
+      </body></html>
+    )
+    send_resp(conn, 400, html)
+  end
+end

--- a/lib/the_maestro/oauth_callback_runtime.ex
+++ b/lib/the_maestro/oauth_callback_runtime.ex
@@ -1,0 +1,129 @@
+defmodule TheMaestro.OAuthCallbackRuntime do
+  @moduledoc """
+  Runtime manager for the OpenAI OAuth callback HTTP server.
+
+  This GenServer stays running under supervision but only starts the HTTP
+  server when requested via `ensure_started/1`. It automatically stops the
+  server after either:
+  - a successful OAuth completion (`notify_success/0`), or
+  - a timeout (default 180_000 ms)
+
+  It can be started again for subsequent auth flows.
+  """
+
+  use GenServer
+
+  @name __MODULE__
+  @default_timeout_ms 180_000
+
+  # Public API
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, %{}, name: @name)
+  end
+
+  @spec ensure_started(keyword()) :: {:ok, %{port: pos_integer()}} | {:error, term()}
+  def ensure_started(opts \\ []) do
+    GenServer.call(@name, {:ensure_started, opts}, 5_000)
+  end
+
+  @spec notify_success() :: :ok
+  def notify_success do
+    GenServer.cast(@name, :oauth_success)
+  end
+
+  @spec stop() :: :ok
+  def stop do
+    GenServer.call(@name, :stop)
+  end
+
+  @spec alive?() :: boolean()
+  def alive? do
+    GenServer.call(@name, :alive?)
+  end
+
+  @spec current_port() :: pos_integer() | nil
+  def current_port do
+    GenServer.call(@name, :current_port)
+  end
+
+  # GenServer callbacks
+  @impl true
+  def init(_), do: {:ok, %{server_pid: nil, timer_ref: nil, port: port_from_env()}}
+
+  @impl true
+  def handle_call({:ensure_started, opts}, _from, state) do
+    timeout_ms = Keyword.get(opts, :timeout_ms, @default_timeout_ms)
+    port = Keyword.get(opts, :port, state.port || port_from_env())
+
+    if is_pid(state.server_pid) and Process.alive?(state.server_pid) do
+      {:reply, {:ok, %{port: port}}, %{state | port: port}}
+    else
+      case Bandit.start_link(
+             plug: TheMaestro.OAuthCallbackPlug,
+             scheme: :http,
+             port: port,
+             thousand_island_options: [num_acceptors: 2]
+           ) do
+        {:ok, pid} ->
+          tref = Process.send_after(self(), :timeout, timeout_ms)
+          {:reply, {:ok, %{port: port}}, %{server_pid: pid, timer_ref: tref, port: port}}
+
+        {:error, reason} ->
+          {:reply, {:error, reason}, %{state | port: port}}
+      end
+    end
+  end
+
+  @impl true
+  def handle_call(:stop, _from, state) do
+    state = stop_server(state)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(:alive?, _from, state) do
+    {:reply, is_pid(state.server_pid) and Process.alive?(state.server_pid), state}
+  end
+
+  @impl true
+  def handle_call(:current_port, _from, state), do: {:reply, state.port, state}
+
+  @impl true
+  def handle_cast(:oauth_success, state) do
+    state = stop_server(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:timeout, state) do
+    state = stop_server(state)
+    {:noreply, state}
+  end
+
+  defp stop_server(%{server_pid: pid, timer_ref: tref} = state) do
+    if is_reference(tref), do: Process.cancel_timer(tref)
+    if is_pid(pid) do
+      # Graceful shutdown
+      ref = Process.monitor(pid)
+      Process.exit(pid, :normal)
+      receive do
+        {:DOWN, ^ref, :process, ^pid, _} -> :ok
+      after
+        2_000 -> :ok
+      end
+    end
+
+    %{server_pid: nil, timer_ref: nil, port: state.port}
+  end
+
+  defp port_from_env do
+    case System.get_env("OPENAI_REDIRECT_PORT") do
+      nil -> 1455
+      s ->
+        case Integer.parse(s) do
+          {p, _} -> p
+          _ -> 1455
+        end
+    end
+  end
+end

--- a/lib/the_maestro/oauth_state.ex
+++ b/lib/the_maestro/oauth_state.ex
@@ -1,0 +1,41 @@
+defmodule TheMaestro.OAuthState do
+  @moduledoc """
+  In-memory store for OAuth transient state → session context.
+
+  Stores mapping of `state` => %{provider, session_name, pkce_params} so that the
+  callback server can complete token exchange with the same PKCE used to generate
+  the OAuth URL.
+  """
+
+  use Agent
+
+  @type t :: %{
+          optional(String.t()) => %{provider: atom(), session_name: String.t(), pkce_params: map()}
+        }
+
+  @name __MODULE__
+
+  def start_link(_opts) do
+    Agent.start_link(fn -> %{} end, name: @name)
+  end
+
+  @spec put(String.t(), %{provider: atom(), session_name: String.t(), pkce_params: map()}) :: :ok
+  def put(state, value) when is_binary(state) and is_map(value) do
+    Agent.update(@name, &Map.put(&1, state, value))
+  end
+
+  @spec get(String.t()) :: map() | nil
+  def get(state) when is_binary(state) do
+    Agent.get(@name, &Map.get(&1, state))
+  end
+
+  @spec take(String.t()) :: map() | nil
+  def take(state) when is_binary(state) do
+    Agent.get_and_update(@name, fn m -> {Map.get(m, state), Map.delete(m, state)} end)
+  end
+
+  @spec delete(String.t()) :: :ok
+  def delete(state) when is_binary(state) do
+    Agent.update(@name, &Map.delete(&1, state))
+  end
+end

--- a/lib/the_maestro/saved_authentication.ex
+++ b/lib/the_maestro/saved_authentication.ex
@@ -188,6 +188,47 @@ defmodule TheMaestro.SavedAuthentication do
   end
 
   @doc """
+  Lists all saved authentications across all providers.
+
+  Results are ordered by `inserted_at` descending, then by provider/auth_type/name
+  for stable display in UIs.
+  """
+  @spec list_all() :: [t()]
+  def list_all do
+    alias TheMaestro.Repo
+    import Ecto.Query
+
+    from(sa in __MODULE__,
+      order_by: [desc: sa.inserted_at, asc: sa.provider, asc: sa.auth_type, asc: sa.name]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Fetches a single saved authentication by id.
+  Raises if not found.
+  """
+  @spec get!(integer()) :: t()
+  def get!(id) when is_integer(id) do
+    alias TheMaestro.Repo
+    Repo.get!(__MODULE__, id)
+  end
+
+  @doc """
+  Updates a saved authentication record.
+
+  Only `name`, `credentials`, and `expires_at` are expected to change post‑creation.
+  Provider and auth_type are treated as immutable for existing records.
+  """
+  @spec update(t(), attrs()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def update(%__MODULE__{} = saved_auth, attrs) do
+    alias TheMaestro.Repo
+    saved_auth
+    |> changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
   Creates a new named session for the given provider and auth type.
 
   ## Parameters

--- a/lib/the_maestro_web/live/auth_edit_live.ex
+++ b/lib/the_maestro_web/live/auth_edit_live.ex
@@ -1,0 +1,97 @@
+defmodule TheMaestroWeb.AuthEditLive do
+  use TheMaestroWeb, :live_view
+
+  alias TheMaestro.Provider
+  alias TheMaestro.SavedAuthentication
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    sa = SavedAuthentication.get!(String.to_integer(id))
+    api_key = Map.get(sa.credentials, "api_key", "")
+
+    {:ok,
+     socket
+     |> assign(:sa, sa)
+     |> assign(:name, sa.name)
+     |> assign(:api_key, api_key)
+     |> assign(:page_title, "Edit Auth")
+     |> assign(:error, nil)}
+  end
+
+  @impl true
+  def handle_event("change", %{"auth" => params}, socket) do
+    {:noreply,
+     socket
+     |> assign(:name, Map.get(params, "name", socket.assigns.name))
+     |> assign(:api_key, Map.get(params, "api_key", socket.assigns.api_key))
+     |> assign(:error, nil)}
+  end
+
+  @impl true
+  def handle_event("save", _params, socket) do
+    sa = socket.assigns.sa
+    with :ok <- Provider.validate_session_name(socket.assigns.name),
+         {:ok, sa} <- maybe_update(sa, socket.assigns) do
+      {:noreply, push_navigate(socket, to: ~p"/auths/#{sa.id}")}
+    else
+      {:error, reason} -> {:noreply, assign(socket, :error, inspect(reason))}
+    end
+  end
+
+  defp maybe_update(sa, assigns) do
+    attrs = %{name: assigns.name}
+    attrs =
+      if sa.auth_type == :api_key do
+        cred = Map.put(sa.credentials || %{}, "api_key", assigns.api_key)
+        Map.put(attrs, :credentials, cred)
+      else
+        attrs
+      end
+
+    SavedAuthentication.update(sa, attrs)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <.link navigate={~p"/auths/#{@sa.id}"} class="btn btn-ghost mb-4">← Back</.link>
+      <h1 class="text-xl font-semibold mb-2">Edit Auth</h1>
+
+      <%= if @error do %>
+        <div class="alert alert-error mb-4">
+          <span><%= @error %></span>
+        </div>
+      <% end %>
+
+      <.form for={%{}} as={:auth} phx-change="change" class="space-y-4">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label class="label">Name</label>
+            <input name="auth[name]" type="text" value={@name} class="input input-bordered w-full" />
+          </div>
+          <div>
+            <label class="label">Provider</label>
+            <input value={@sa.provider} class="input input-bordered w-full" disabled />
+          </div>
+          <div>
+            <label class="label">Auth Type</label>
+            <input value={@sa.auth_type} class="input input-bordered w-full" disabled />
+          </div>
+        </div>
+
+        <%= if @sa.auth_type == :api_key do %>
+          <div>
+            <label class="label">API Key</label>
+            <input name="auth[api_key]" type="password" value={@api_key} class="input input-bordered w-full" />
+          </div>
+        <% end %>
+
+        <div class="mt-4">
+          <button type="button" phx-click="save" class="btn btn-primary">Save</button>
+        </div>
+      </.form>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/the_maestro_web/live/auth_new_live.ex
+++ b/lib/the_maestro_web/live/auth_new_live.ex
@@ -1,0 +1,220 @@
+defmodule TheMaestroWeb.AuthNewLive do
+  use TheMaestroWeb, :live_view
+
+  alias TheMaestro.Auth
+  alias TheMaestro.Provider
+
+  @providers [:openai, :anthropic, :gemini]
+  @auth_types [:oauth, :api_key]
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Create New Auth")
+     |> assign(:providers, @providers)
+     |> assign(:auth_types, @auth_types)
+     |> assign(:name, "")
+     |> assign(:provider, hd(@providers))
+     |> assign(:auth_type, hd(@auth_types))
+     |> assign(:api_key, "")
+     |> assign(:user_project, "")
+     |> assign(:oauth_url, nil)
+     |> assign(:pkce_params, nil)
+     |> assign(:auth_code, "")
+     |> assign(:error, nil)}
+  end
+
+  @impl true
+  def handle_event("change", %{"auth" => params}, socket) do
+    {:noreply,
+     socket
+     |> assign(:name, Map.get(params, "name", socket.assigns.name))
+     |> assign(:provider, parse_atom(Map.get(params, "provider")) || socket.assigns.provider)
+     |> assign(:auth_type, parse_atom(Map.get(params, "auth_type")) || socket.assigns.auth_type)
+     |> assign(:api_key, Map.get(params, "api_key", socket.assigns.api_key))
+     |> assign(:user_project, Map.get(params, "user_project", socket.assigns.user_project))
+     |> assign(:auth_code, Map.get(params, "auth_code", socket.assigns.auth_code))
+     |> assign(:error, nil)}
+  end
+
+  @impl true
+  def handle_event("generate_oauth_url", _params, socket) do
+    with :ok <- Provider.validate_session_name(socket.assigns.name),
+         {:ok, {url, pkce}} <- oauth_url_for(socket.assigns.provider) do
+      url_state = extract_state(url)
+
+      socket =
+        if socket.assigns.provider == :openai and is_binary(url_state) do
+          # Save mapping so callback server can complete flow
+          TheMaestro.OAuthState.put(url_state, %{
+            provider: :openai,
+            session_name: socket.assigns.name,
+            pkce_params: Map.new(pkce_to_kw(pkce))
+          })
+          # Ensure callback runtime is running with 180s timeout
+          {:ok, %{port: port}} = TheMaestro.OAuthCallbackRuntime.ensure_started(timeout_ms: 180_000)
+          socket
+          |> assign(:callback_port, port)
+          |> assign(:callback_listening, true)
+        else
+          socket
+        end
+
+      {:noreply,
+       socket
+       |> assign(:oauth_url, url)
+       |> assign(:pkce_params, pkce)
+       |> assign(:error, nil)}
+    else
+      {:error, reason} -> {:noreply, assign(socket, :error, inspect(reason))}
+    end
+  end
+
+  @impl true
+  def handle_event("create_api_key", _params, socket) do
+    opts =
+      case socket.assigns.provider do
+        :gemini -> [name: socket.assigns.name, credentials: %{api_key: socket.assigns.api_key, user_project: blank_to_nil(socket.assigns.user_project)}]
+        _ -> [name: socket.assigns.name, credentials: %{api_key: socket.assigns.api_key}]
+      end
+
+    case Provider.create_session(socket.assigns.provider, :api_key, opts) do
+      {:ok, _session} -> {:noreply, push_navigate(socket, to: ~p"/dashboard")}
+      {:error, reason} -> {:noreply, assign(socket, :error, inspect(reason))}
+    end
+  end
+
+  @impl true
+  def handle_event("complete_oauth", _params, socket) do
+    with :ok <- Provider.validate_session_name(socket.assigns.name),
+         pkce when not is_nil(pkce) <- socket.assigns.pkce_params || {:error, "Generate the OAuth URL first"},
+         code when is_binary(code) and code != "" <- socket.assigns.auth_code || {:error, "Enter the authorization code"},
+         {:ok, _} <-
+           Provider.create_session(socket.assigns.provider, :oauth,
+             name: socket.assigns.name,
+             pkce_params: pkce_to_kw(pkce),
+             auth_code: code
+           ) do
+      {:noreply, push_navigate(socket, to: ~p"/dashboard")}
+    else
+      {:error, reason} -> {:noreply, assign(socket, :error, inspect(reason))}
+      msg when is_binary(msg) -> {:noreply, assign(socket, :error, msg)}
+    end
+  end
+
+  defp oauth_url_for(:openai), do: Auth.generate_openai_oauth_url()
+  defp oauth_url_for(:anthropic), do: Auth.generate_oauth_url()
+  defp oauth_url_for(:gemini), do: Auth.generate_gemini_oauth_url()
+
+  defp pkce_to_kw(%Auth.PKCEParams{} = pkce), do: [code_verifier: pkce.code_verifier, code_challenge: pkce.code_challenge, code_challenge_method: pkce.code_challenge_method]
+  defp pkce_to_kw(%{code_verifier: v} = pkce), do: [code_verifier: v, code_challenge: Map.get(pkce, :code_challenge) || Map.get(pkce, "code_challenge"), code_challenge_method: Map.get(pkce, :code_challenge_method) || Map.get(pkce, "code_challenge_method")]
+
+  defp parse_atom(nil), do: nil
+  defp parse_atom(val) when is_binary(val), do: String.to_existing_atom(val)
+  defp parse_atom(val) when is_atom(val), do: val
+
+  defp extract_state(url) when is_binary(url) do
+    url
+    |> URI.parse()
+    |> Map.get(:query)
+    |> Kernel.||("")
+    |> URI.decode_query()
+    |> Map.get("state")
+  rescue
+    _ -> nil
+  end
+
+  defp blank_to_nil("") , do: nil
+  defp blank_to_nil(v), do: v
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <h1 class="text-xl font-semibold mb-4">Create New Auth</h1>
+      <.link navigate={~p"/dashboard"} class="btn btn-ghost mb-4">← Back</.link>
+
+      <%= if @error do %>
+        <div class="alert alert-error mb-4">
+          <span><%= @error %></span>
+        </div>
+      <% end %>
+
+      <.form for={%{}} as={:auth} phx-change="change" class="space-y-4">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label class="label">Name</label>
+            <input name="auth[name]" type="text" value={@name} placeholder="e.g. work_openai" class="input input-bordered w-full" />
+          </div>
+          <div>
+            <label class="label">Provider</label>
+            <select name="auth[provider]" class="select select-bordered w-full" value={@provider}>
+              <%= for p <- @providers do %>
+                <option value={p} selected={@provider == p}><%= p %></option>
+              <% end %>
+            </select>
+          </div>
+          <div>
+            <label class="label">Auth Type</label>
+            <select name="auth[auth_type]" class="select select-bordered w-full" value={@auth_type}>
+              <%= for t <- @auth_types do %>
+                <option value={t} selected={@auth_type == t}><%= t %></option>
+              <% end %>
+            </select>
+          </div>
+        </div>
+
+        <%= if @auth_type == :api_key do %>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div class="sm:col-span-2">
+              <label class="label">API Key</label>
+              <input name="auth[api_key]" type="password" value={@api_key} class="input input-bordered w-full" />
+            </div>
+            <%= if @provider == :gemini do %>
+              <div class="sm:col-span-2">
+                <label class="label">X-Goog-User-Project (optional)</label>
+                <input name="auth[user_project]" type="text" value={@user_project} class="input input-bordered w-full" placeholder="billing-project-id" />
+              </div>
+            <% end %>
+          </div>
+          <div class="mt-4">
+            <button type="button" phx-click="create_api_key" class="btn btn-primary">Create</button>
+          </div>
+        <% else %>
+          <div class="space-y-3">
+            <div class="flex gap-2 items-end">
+              <button type="button" phx-click="generate_oauth_url" class="btn">Generate OAuth URL</button>
+              <%= if @oauth_url do %>
+                <a href={@oauth_url} target="_blank" class="btn btn-primary">Open OAuth Page</a>
+              <% end %>
+            </div>
+            <%= if @oauth_url && @provider == :openai do %>
+              <p class="text-sm opacity-80">
+                <%= if @callback_listening do %>
+                  Listening on <code>http://localhost:<%= @callback_port || 1455 %>/auth/callback</code> for 180 seconds.
+                <% else %>
+                  Initializing callback listener...
+                <% end %>
+                <br/>
+                After authorization, we will auto-complete and return you to the dashboard.
+              </p>
+            <% end %>
+            <%= if @oauth_url && @provider != :openai do %>
+              <div>
+                <label class="label">Authorization Code</label>
+                <input name="auth[auth_code]" type="text" value={@auth_code} class="input input-bordered w-full" placeholder="Paste code from provider callback" />
+              </div>
+              <div class="mt-2">
+                <button type="button" phx-click="complete_oauth" class="btn btn-success">Complete OAuth</button>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </.form>
+    </Layouts.app>
+    """
+  end
+
+  # assigns are set in mount
+end

--- a/lib/the_maestro_web/live/auth_show_live.ex
+++ b/lib/the_maestro_web/live/auth_show_live.ex
@@ -1,0 +1,61 @@
+defmodule TheMaestroWeb.AuthShowLive do
+  use TheMaestroWeb, :live_view
+
+  alias TheMaestro.Provider
+  alias TheMaestro.SavedAuthentication
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    sa = SavedAuthentication.get!(String.to_integer(id))
+    {:ok, assign(socket, :sa, sa) |> assign(:page_title, "Auth Details")}
+  end
+
+  @impl true
+  def handle_event("refresh_tokens", _params, socket) do
+    sa = socket.assigns.sa
+    case Provider.refresh_tokens(String.to_atom(sa.provider), sa.name) do
+      {:ok, _} -> {:noreply, assign(socket, :sa, SavedAuthentication.get!(sa.id))}
+      {:error, reason} -> {:noreply, put_flash(socket, :error, inspect(reason))}
+    end
+  end
+
+  defp format_dt(nil), do: "—"
+  defp format_dt(%DateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S %Z")
+  defp format_dt(%NaiveDateTime{} = ndt), do: Calendar.strftime(ndt, "%Y-%m-%d %H:%M:%S") <> " UTC"
+
+  defp redact_credentials(%{"api_key" => _} = cred), do: Map.put(cred, "api_key", "••••••••••")
+  defp redact_credentials(%{"access_token" => _} = cred), do: Map.put(cred, "access_token", "••••••••••")
+  defp redact_credentials(cred) when is_map(cred), do: cred
+  defp redact_credentials(_), do: %{}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <.link navigate={~p"/dashboard"} class="btn btn-ghost mb-4">← Back</.link>
+      <h1 class="text-xl font-semibold mb-2">Auth Details</h1>
+
+      <div class="card bg-base-200 p-4 space-y-2">
+        <div><b>Name:</b> {@sa.name}</div>
+        <div><b>Provider:</b> {@sa.provider}</div>
+        <div><b>Auth Type:</b> {@sa.auth_type}</div>
+        <div><b>Expires:</b> {format_dt(@sa.expires_at)}</div>
+        <div><b>Created:</b> {format_dt(@sa.inserted_at)}</div>
+        <div><b>Updated:</b> {format_dt(@sa.updated_at)}</div>
+        <div class="mt-2">
+          <details>
+            <summary class="cursor-pointer">Credentials (redacted)</summary>
+            <pre class="mt-2 text-xs">{inspect(redact_credentials(@sa.credentials), pretty: true)}</pre>
+          </details>
+        </div>
+        <div class="mt-3 space-x-2">
+          <%= if @sa.auth_type == :oauth do %>
+            <button phx-click="refresh_tokens" class="btn btn-xs">Refresh Tokens</button>
+          <% end %>
+          <.link navigate={~p"/auths/#{@sa.id}/edit"} class="btn btn-xs">Edit</.link>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/the_maestro_web/live/dashboard_live.ex
+++ b/lib/the_maestro_web/live/dashboard_live.ex
@@ -1,0 +1,97 @@
+defmodule TheMaestroWeb.DashboardLive do
+  use TheMaestroWeb, :live_view
+
+  alias TheMaestro.Provider
+  alias TheMaestro.SavedAuthentication
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: TheMaestroWeb.Endpoint.subscribe("oauth:events")
+
+    {:ok,
+     socket
+     |> assign(:auths, SavedAuthentication.list_all())
+     |> assign(:page_title, "Dashboard")}
+  end
+
+  @impl true
+  def handle_params(_params, _uri, socket) do
+    {:noreply, assign(socket, :auths, SavedAuthentication.list_all())}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    case Integer.parse(id) do
+      {int, _} ->
+        sa = SavedAuthentication.get!(int)
+        # Normalize provider to atom safely
+        # Use Provider wrapper for idempotent deletion
+        _ = Provider.delete_session(sa.provider, sa.auth_type, sa.name)
+        {:noreply, assign(socket, :auths, SavedAuthentication.list_all())}
+
+      :error ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_info(%{topic: "oauth:events", event: "completed", payload: payload}, socket) do
+    # Refresh list when a new auth is persisted by the callback server
+    {:noreply,
+     socket
+     |> put_flash(:info, "OAuth completed for #{payload["provider"]}: #{payload["session_name"]}")
+     |> assign(:auths, SavedAuthentication.list_all())}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  defp format_dt(nil), do: "—"
+  defp format_dt(%DateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S %Z")
+  defp format_dt(%NaiveDateTime{} = ndt), do: Calendar.strftime(ndt, "%Y-%m-%d %H:%M:%S") <> " UTC"
+
+  defp provider_label(p) when is_atom(p), do: Atom.to_string(p)
+  defp provider_label(p) when is_binary(p), do: p
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-xl font-semibold">Dashboard</h1>
+        <.link navigate={~p"/auths/new"} class="btn btn-primary">New Auth</.link>
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="table table-zebra w-full">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Provider</th>
+              <th>Auth Type</th>
+              <th>Expiration</th>
+              <th>Created</th>
+              <th class="w-40">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for sa <- @auths do %>
+              <tr id={"auth-#{sa.id}"}>
+                <td><%= sa.name %></td>
+                <td><%= provider_label(sa.provider) %></td>
+                <td class="uppercase"><%= sa.auth_type %></td>
+                <td><%= format_dt(sa.expires_at) %></td>
+                <td><%= format_dt(sa.inserted_at) %></td>
+                <td class="space-x-2">
+                  <.link navigate={~p"/auths/#{sa.id}"} class="btn btn-xs">View</.link>
+                  <.link navigate={~p"/auths/#{sa.id}/edit"} class="btn btn-xs">Edit</.link>
+                  <button phx-click="delete" phx-value-id={sa.id} data-confirm="Delete this auth?" class="btn btn-xs btn-error">Delete</button>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/the_maestro_web/router.ex
+++ b/lib/the_maestro_web/router.ex
@@ -16,8 +16,11 @@ defmodule TheMaestroWeb.Router do
 
   scope "/", TheMaestroWeb do
     pipe_through :browser
-
-    get "/", PageController, :home
+    live "/", DashboardLive, :index
+    live "/dashboard", DashboardLive, :index
+    live "/auths/new", AuthNewLive, :new
+    live "/auths/:id", AuthShowLive, :show
+    live "/auths/:id/edit", AuthEditLive, :edit
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
## Summary

This PR introduces a new Dashboard landing page with full Saved Auths management (list/view/edit/delete) and integrates an OpenAI OAuth flow that uses a lightweight on-demand callback server (Bandit) with a 180-second timeout and automatic shutdown on completion. It also adds an in-memory OAuth state store so the redirect can reuse the exact PKCE generated when the OAuth URL was created.

Key points:
- New Dashboard LiveView as the landing page (lists saved authentications)
- New Auth flow with provider and auth type selection
  - OpenAI OAuth: on-demand callback listener at `http://localhost:1455/auth/callback`, auto-stops after success or 180s
  - Anthropic OAuth: manual code paste flow
  - Gemini API key: optional `X-Goog-User-Project` support
- Dashboard auto-refreshes on OAuth completion via PubSub event
- Provider.create_session validation now supports OAuth input (auth_code + pkce_params)
- UI fixes: robust date formatting (NaiveDateTime), boolean guard safety in HEEx, PKCE list/map normalization

## Implementation Details

- LiveViews
  - `DashboardLive`: index/landing (/, /dashboard)
  - `AuthNewLive`: create new auth (OpenAI/Gemini/Anthropic flows)
  - `AuthShowLive`: details (with redacted credentials + Refresh Tokens for OAuth)
  - `AuthEditLive`: rename + update API key
- OAuth runtime
  - `OAuthCallbackRuntime`: GenServer that starts Bandit only when needed; stops on success or 180s timeout
  - `OAuthCallbackPlug`: handles GET /auth/callback, completes session creation, broadcasts completion
  - `OAuthState`: Agent for state => %{provider, session_name, pkce_params}
- SavedAuthentication
  - Helpers for list_all/get!/update used by UI
- Provider validation
  - Accepts either credentials (API key) OR (auth_code + pkce_params) for OAuth flows

## New Routes
- `/` and `/dashboard` → Dashboard
- `/auths/new` → New Auth
- `/auths/:id` → View
- `/auths/:id/edit` → Edit

## Testing Steps
1. Start app: `mix phx.server`
2. Visit `/` → Dash should load (empty initially)
3. New Auth → provider=OpenAI, auth_type=OAuth → Generate URL → Open OAuth Page
4. Complete consent → callback page shows success; server shuts down
5. Dashboard flashes “OAuth completed …” and lists new auth (OpenAI)
6. Delete an auth from Dashboard – row disappears
7. Anthropic OAuth: Generate URL → paste code → Complete OAuth
8. Gemini API key: add key (and optional X-Goog-User-Project) → Create

## Notes
- Callback port defaults to 1455 (`OPENAI_REDIRECT_PORT` overrides)
- Listener timeout is 180 seconds (configurable in code when calling runtime)
- Consider follow-ups: countdown UI, “restart listener” button, env-configurable timeout

## Screens/UX Considerations
- Uses existing app layout & Tailwind/daisyUI
- Minimal copy; we can expand help text in a follow-up PR

